### PR TITLE
Add domUpdates with renderUserTrips method

### DIFF
--- a/src/dom-updates.js
+++ b/src/dom-updates.js
@@ -1,0 +1,19 @@
+let domUpdates = {
+
+  // toggleMainView(loginNode, navNode, mainNode) {
+  //   loginNode.classList.toggle('hidden');
+  //   navNode.classList.toggle('hidden');
+  //   mainNode.classList.toggle('hidden');
+  // },
+
+  renderUserTrips(traveler, allDestinations, tripsNode) {
+    traveler.trips.forEach(trip => {
+      tripsNode.insertAdjacentHTML(`before-end`, 
+        `<p>Destination: ${allDestinations[trip.destinationID - 1].destination}</p>
+        <p>Travelers: ${trip.travelers}</p>
+        <p>Date: ${trip.date}</p>
+        <p>Status: ${trip.status}</p>`
+      );
+    });
+  }
+}

--- a/test/dom-updates-test.js
+++ b/test/dom-updates-test.js
@@ -1,0 +1,21 @@
+const chai = require('chai');
+const expect = chai.expect;
+const spies = require('chai-spies');
+import domUpdates from '../src/dom-updates';
+
+chai.use(spies);
+
+describe('domUpdates', () => {
+  beforeEach(() => {
+    chai.spy.on(domUpdates, ['renderUserTrips'], () => true)
+  });
+
+  afterEach(() => {
+    chai.spy.restore(domUpdates);
+  });
+
+  it('should be able to render user trips to the DOM', () => {
+    domUpdates.renderUserTrips();
+    expect(domUpdates.renderUserTrips).to.have.been.called(1);
+  });
+});


### PR DESCRIPTION
## Description
Added a domUpdates object to handle all DOM updates, added a method to render the user trips to the booked trips node of the DOM

## Context
I needed to seperate my DOM updates into their own file for SRP. I will invoke the necessary methods of this object in `index.js` in a future iteration.

## Where To Start
dom-updates.js

## Affected areas of application
N/A

## How Has This Been Tested?
- [x] Mocha / Chai / Spies

## Relevant Tickets
Closes #40 

## Questions or Notes (if applicable):
N/A