### PR TITLE
Fix destination cards duplicating

### DIFF
--- a/src/dom-updates.js
+++ b/src/dom-updates.js
@@ -34,6 +34,7 @@ let domUpdates = {
   },
 
   renderDesinationCards(traveler) {
+    nodes.destinationsBody.innerHTML = '';
     traveler.allDestinations.forEach(destination => {
       nodes.destinationsBody.insertAdjacentHTML('beforeend',
         `<article class="sub-sub-card" id="desinations-sub-card">


### PR DESCRIPTION
## Description
Fixed destination cards getting duplicated with requesting a trip. renderDesinationCards now resets the innerHTML when it is invoked.

## Context
I needed to fix a bug with the destination cards being duplicated.

## Where To Start
dom-updates.js

## Affected areas of application
N/A

## How Has This Been Tested?
- [x] Mocha / Chai
- [x] Chrome Inspector

## Relevant Tickets
Closes #79 

## Questions or Notes (if applicable):
N/A